### PR TITLE
Add MIRAI precondition annotations to functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dev = ["std", "nightly_allocator_api"]
 [dependencies]
 cfg-if = "1.0"
 libc = "0.2"
+mirai-annotations = "1.12"
 thiserror = {version = "1.0", optional = true}
 
 [dev-dependencies]

--- a/justfile
+++ b/justfile
@@ -47,3 +47,12 @@ dist-clean: clean
 
 generate-readme:
     cargo doc2readme
+
+dev-mirai:
+    env RUSTFLAGS="-Z always_encode_mir" env RUSTC_WRAPPER=mirai env MIRAI_FLAGS="--diag=library" cargo +nightly-2021-09-17 build --no-default-features --features nightly --features std
+
+clean-mirai: clean
+    env RUSTFLAGS="-Z always_encode_mir" cargo +nightly-2021-09-17 build --no-default-features --features nightly --features std
+    touch src/lib.rs
+    env RUSTFLAGS="-Z always_encode_mir" env RUSTC_WRAPPER=mirai env MIRAI_FLAGS="--diag=library" cargo +nightly-2021-09-17 build --no-default-features --features nightly --features std
+

--- a/src/allocator_api.rs
+++ b/src/allocator_api.rs
@@ -7,6 +7,7 @@ use crate::util::nonnull_as_mut_ptr;
 use core::alloc::Layout;
 use core::fmt;
 use core::ptr::{self, NonNull};
+use mirai_annotations::debug_checked_precondition;
 
 /// The `AllocError` error indicates an allocation failure
 /// that may be due to resource exhaustion or to
@@ -202,7 +203,7 @@ pub unsafe trait Allocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        debug_assert!(
+        debug_checked_precondition!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
         );
@@ -273,7 +274,7 @@ pub unsafe trait Allocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        debug_assert!(
+        debug_checked_precondition!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
         );
@@ -347,7 +348,7 @@ pub unsafe trait Allocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        debug_assert!(
+        debug_checked_precondition!(
             new_layout.size() <= old_layout.size(),
             "`new_layout.size()` must be smaller than or equal to `old_layout.size()`"
         );

--- a/src/internals/zeroize.rs
+++ b/src/internals/zeroize.rs
@@ -3,6 +3,8 @@
 //! Contains wrappers around intrinsics and ffi functions necessary for the
 //! [`crate::zeroize`] module.
 
+use crate::macros::precondition_memory_range;
+
 /// Volatile write byte to memory.
 ///
 /// This uses the [`core::intrinsics::volatile_set_memory`] intrinsic and can
@@ -15,6 +17,7 @@
 // about bytes (therefore byte alignment), it *always* is.
 #[cfg(feature = "nightly_core_intrinsics")]
 pub unsafe fn volatile_memset(ptr: *mut u8, val: u8, len: usize) {
+    precondition_memory_range!(ptr, len);
     // SAFETY: the caller must uphold the safety contract
     unsafe {
         core::intrinsics::volatile_set_memory(ptr, val, len);
@@ -40,6 +43,7 @@ pub unsafe fn volatile_memset(ptr: *mut u8, val: u8, len: usize) {
     target_env = "musl"
 ))]
 pub unsafe fn libc_explicit_bzero(ptr: *mut u8, len: usize) {
+    precondition_memory_range!(ptr, len);
     // SAFETY: the caller must uphold the safety contract
     unsafe {
         libc::explicit_bzero(ptr as *mut libc::c_void, len as libc::size_t);
@@ -59,6 +63,7 @@ pub unsafe fn libc_explicit_bzero(ptr: *mut u8, len: usize) {
 // about bytes (therefore byte alignment), it *always* is.
 #[cfg(target_os = "netbsd")]
 pub unsafe fn libc_explicit_bzero(ptr: *mut u8, len: usize) {
+    precondition_memory_range!(ptr, len);
     // SAFETY: the caller must uphold the safety contract
     unsafe {
         libc::explicit_memset(
@@ -82,6 +87,7 @@ pub unsafe fn libc_explicit_bzero(ptr: *mut u8, len: usize) {
 // about bytes (therefore byte alignment), it *always* is.
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub unsafe fn libc_explicit_bzero(ptr: *mut u8, len: usize) {
+    precondition_memory_range!(ptr, len);
     // SAFETY: the caller must uphold the safety contract
     unsafe {
         // the zero value is a `c_int` (`i32` by default), but then converted to
@@ -111,6 +117,7 @@ pub unsafe fn libc_explicit_bzero(ptr: *mut u8, len: usize) {
 // about bytes (therefore byte alignment), it *always* is.
 #[cfg(all(target_arch = "x86_64", target_feature = "ermsb", feature = "cc"))]
 pub unsafe fn c_asm_ermsb_zeroize(ptr: *mut u8, len: usize) {
+    precondition_memory_range!(ptr, len);
     extern "C" {
         fn zeroize_volatile(ptr: *mut u8, count: usize);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@
 extern crate alloc;
 
 mod internals;
+mod macros;
 mod util;
 
 #[cfg(not(feature = "nightly_allocator_api"))]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,44 @@
+//! Macros used in the crate source.
+
+macro_rules! debug_handleallocerror_precondition {
+    ($condition:expr, $layout:ident) => {
+        mirai_annotations::precondition!($condition);
+        if cfg!(debug_assertions) {
+            // check that `layout` is a valid layout
+            if !($condition) {
+                handle_alloc_error($layout);
+            }
+        }
+    };
+}
+
+macro_rules! debug_handleallocerror_precondition_valid_layout {
+    ($layout:ident) => {
+        mirai_annotations::precondition!(
+            Layout::from_size_align($layout.size(), $layout.align()).is_ok(),
+            "invalid layout"
+        );
+        if cfg!(debug_assertions) {
+            // check that `layout` is a valid layout
+            if Layout::from_size_align($layout.size(), $layout.align()).is_err() {
+                handle_alloc_error($layout);
+            }
+        }
+    };
+}
+
+macro_rules! precondition_memory_range {
+    ($ptr:expr, $len:expr) => {
+        // !($ptr.is_null())
+        mirai_annotations::precondition!(!($ptr.is_null()), "null pointer is never valid");
+        mirai_annotations::precondition!(
+            ($ptr as usize).checked_add($len).is_some(),
+            "memory range wraps the address space"
+        );
+    };
+}
+
+pub(crate) use {
+    debug_handleallocerror_precondition, debug_handleallocerror_precondition_valid_layout,
+    precondition_memory_range,
+};

--- a/src/sec_alloc.rs
+++ b/src/sec_alloc.rs
@@ -27,6 +27,7 @@ use crate::zeroize::{DefaultMemZeroizer, MemZeroizer};
 use core::alloc::Layout;
 use core::cell::Cell;
 use core::ptr::{self, NonNull};
+use mirai_annotations::debug_checked_precondition;
 
 /// Memory allocator for confidential memory. See the module level
 /// documentation.
@@ -234,7 +235,7 @@ impl<Z: MemZeroizer> SecStackSinglePageAlloc<Z> {
     /// `align` must be a power of 2
     #[must_use]
     pub unsafe fn allocate_zerosized(align: usize) -> NonNull<[u8]> {
-        debug_assert!(align.is_power_of_two());
+        debug_checked_precondition!(align.is_power_of_two());
 
         // SAFETY: creating a pointer is safe, using it not; `dangling` is non-null
         let dangling: *mut u8 = align as *mut u8;
@@ -263,7 +264,7 @@ impl<Z: MemZeroizer> SecStackSinglePageAlloc<Z> {
     ) -> Result<NonNull<[u8]>, AllocError> {
         // like the default implementation of `Allocator::shrink` in the standard
         // library
-        debug_assert!(
+        debug_checked_precondition!(
             new_layout.size() <= old_layout.size(),
             "`new_layout.size()` must be smaller than or equal to `old_layout.size()`"
         );
@@ -303,7 +304,7 @@ impl<Z: MemZeroizer> SecStackSinglePageAlloc<Z> {
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
         // like the default implementation of `Allocator::grow` in the standard library
-        debug_assert!(
+        debug_checked_precondition!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
         );
@@ -332,8 +333,7 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
     // allows for fast zeroization and reduces the chance for (external) memory
     // fragmentation, at the cost of increased internal memory fragmentation.
     fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        debug_assert!(layout.align() != 0); // implied by power of 2, but *very important* (safety)
-        debug_assert!(layout.align().is_power_of_two());
+        debug_checked_precondition!(layout.align().is_power_of_two());
 
         // catch zero sized allocations immediately so we do not have to bother with
         // them
@@ -449,8 +449,8 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
 
         // `ptr` must be returned by this allocator, so it lies in the currently used
         // part of the memory page
-        debug_assert!(self.page.as_ptr() as usize <= ptr.as_ptr() as usize);
-        debug_assert!(
+        debug_checked_precondition!(self.page.as_ptr() as usize <= ptr.as_ptr() as usize);
+        debug_checked_precondition!(
             ptr.as_ptr() as usize <= self.page.as_ptr() as usize + self.stack_offset.get()
         );
 
@@ -503,7 +503,7 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        debug_assert!(
+        debug_checked_precondition!(
             new_layout.size() <= old_layout.size(),
             "`new_layout.size()` must be smaller than or equal to `old_layout.size()`"
         );
@@ -522,8 +522,8 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
 
         // `ptr` must be returned by this allocator, so it lies in the currently used
         // part of the memory page
-        debug_assert!(self.page.as_ptr() as usize <= ptr.as_ptr() as usize);
-        debug_assert!(
+        debug_checked_precondition!(self.page.as_ptr() as usize <= ptr.as_ptr() as usize);
+        debug_checked_precondition!(
             ptr.as_ptr() as usize <= self.page.as_ptr() as usize + self.stack_offset.get()
         );
 
@@ -597,7 +597,7 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        debug_assert!(
+        debug_checked_precondition!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
         );
@@ -611,8 +611,8 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
 
         // `ptr` must be returned by this allocator, so it lies in the currently used
         // part of the memory page
-        debug_assert!(self.page.as_ptr() as usize <= ptr.as_ptr() as usize);
-        debug_assert!(
+        debug_checked_precondition!(self.page.as_ptr() as usize <= ptr.as_ptr() as usize);
+        debug_checked_precondition!(
             ptr.as_ptr() as usize <= self.page.as_ptr() as usize + self.stack_offset.get()
         );
 


### PR DESCRIPTION
MIRAI will still give some warnings since it is not "smart" enough to reach some conclusions based on the given preconditions... (in particular everything with modulo operations seems to be hard)