### PR TITLE
Maintenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "secmem-alloc"
 version = "0.1.1"
 authors = ["niluxv <niluxv.opensource.C-h2ty6xl@yandex.com>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 license = "MIT OR Apache-2.0"
 description = "Custom allocators for secret memory"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 
 [features]
 default = ["std", "cc"]
-std = ["thiserror"]
+std = ["thiserror", "winapi/std"]
 nightly_allocator_api = []
 nightly_core_intrinsics = []
 nightly = ["nightly_allocator_api", "nightly_core_intrinsics"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,7 @@
 # some of these options are still unstable
 unstable_features = true
-# use edition 2018 by default
-edition = "2018"
+# use edition 2021 by default
+edition = "2021"
 # make formatting somewhat more aggressive
 format_code_in_doc_comments = true
 format_macro_matchers = true

--- a/src/internals/mem.rs
+++ b/src/internals/mem.rs
@@ -5,10 +5,10 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 #[cfg(unix)]
 use libc::{c_int, off_t, size_t};
-#[cfg(windows)]
-use winapi::ctypes::c_void;
 #[cfg(feature = "std")]
 use thiserror::Error;
+#[cfg(windows)]
+use winapi::ctypes::c_void;
 
 /// Return the page size on the running system.
 ///

--- a/src/internals/mem.rs
+++ b/src/internals/mem.rs
@@ -1,8 +1,12 @@
 //! Helper functions for allocating memory and working with memory pages.
 
+#[cfg(unix)]
 use core::ffi::c_void;
 use core::ptr::NonNull;
+#[cfg(unix)]
 use libc::{c_int, off_t, size_t};
+#[cfg(windows)]
+use winapi::ctypes::c_void;
 #[cfg(feature = "std")]
 use thiserror::Error;
 
@@ -20,12 +24,12 @@ cfg_if::cfg_if! {
     if #[cfg(miri)] {
         /// Page size shim for miri.
         #[cfg(not(tarpaulin_include))]
-        fn get_sys_page_size() -> size_t {
+        fn get_sys_page_size() -> usize {
             4096
         }
     } else if #[cfg(unix)] {
         /// Return the page size on the running system by querying libc.
-        fn get_sys_page_size() -> size_t {
+        fn get_sys_page_size() -> usize {
             unsafe {
                 // the pagesize must always fit in a `size_t` (`usize`)
                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -36,7 +40,7 @@ cfg_if::cfg_if! {
         }
     } else if #[cfg(windows)] {
         /// Return the page size on the running system by querying kernel32.lib.
-        fn get_sys_page_size() -> size_t {
+        fn get_sys_page_size() -> usize {
             use winapi::um::sysinfoapi::{LPSYSTEM_INFO, GetSystemInfo, SYSTEM_INFO};
 
             let mut sysinfo = SYSTEM_INFO::default();
@@ -45,10 +49,10 @@ cfg_if::cfg_if! {
             unsafe {
                 GetSystemInfo(sysinfo_ptr)
             };
-            // the pagesize must always fit in a `size_t` (`usize`) (on windows it is a `u32`)
+            // the pagesize must always fit in a `usize` (on windows it is a `u32`)
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             {
-                sysinfo.dwPageSize as size_t
+                sysinfo.dwPageSize as usize
             }
         }
     }

--- a/src/sec_alloc.rs
+++ b/src/sec_alloc.rs
@@ -906,13 +906,13 @@ mod tests {
             let mut heap_mem = Vec::<u8, _>::with_capacity_in(9, &allocator);
             allocator.consistency_check();
             {
-                let heap_mem2 = Box::new_in(37_u64, &allocator);
+                let _heap_mem2 = Box::new_in(37_u64, &allocator);
                 allocator.consistency_check();
                 heap_mem.reserve(10);
                 allocator.consistency_check();
                 heap_mem.reserve(17);
                 allocator.consistency_check();
-            } // drop `heap_mem2`
+            } // drop `_heap_mem2`
             allocator.consistency_check();
         } // drop `heap_mem`
         allocator.consistency_check();
@@ -948,13 +948,13 @@ mod tests {
             let mut heap_mem = Vec::<u8, _>::with_capacity_in(9, &allocator);
             allocator.consistency_check();
             {
-                let heap_mem2 = Box::new_in(37_u64, &allocator);
+                let _heap_mem2 = Box::new_in(37_u64, &allocator);
                 allocator.consistency_check();
                 heap_mem.push(1);
                 allocator.consistency_check();
                 heap_mem.shrink_to_fit();
                 allocator.consistency_check();
-            } // drop `heap_mem2`
+            } // drop `_heap_mem2`
             allocator.consistency_check();
         } // drop `heap_mem`
         allocator.consistency_check();

--- a/src/zeroize.rs
+++ b/src/zeroize.rs
@@ -54,7 +54,7 @@ pub trait MemZeroizer {
     /// known at compile time. Therefore it is fine to underestimate the
     /// alignment, especially if this underestimate can be known at compile
     /// time.
-    unsafe fn zeroize_mem_minaligned(&self, ptr: *mut u8, len: usize, align: usize) {
+    unsafe fn zeroize_mem_minaligned(&self, ptr: *mut u8, len: usize, _align: usize) {
         precondition_memory_range!(ptr, len);
         // SAFETY: caller must uphold the safety contract of `self.zeroize_mem` (and
         // more)

--- a/src/zeroize.rs
+++ b/src/zeroize.rs
@@ -315,51 +315,46 @@ unsafe fn volatile_write_zeroize_mem(mut ptr: *mut u8, len: usize) {
 /// the [`std::ptr`] documentation. In particular this function is not atomic.
 ///
 /// Furthermore, `ptr` *must* be at least 8 byte aligned.
-unsafe fn volatile_write8_zeroize_mem(ptr: *mut u8, len: usize) {
+unsafe fn volatile_write8_zeroize_mem(mut ptr: *mut u8, len: usize) {
     precondition_memory_range!(ptr, len);
     debug_checked_precondition_eq!((ptr as usize) % 8, 0);
     let nblocks = (len - len % 8) / 8;
-    for i in 0..nblocks {
-        // ptr as usize + 8*i can't overlow because `ptr` is valid for writes of `len`
-        // SAFETY: `8*i + 8 =<  len`, so `ptr_new` will be valid for 8 bytes write
-        let ptr_new: *mut u8 = ((ptr as usize) + 8 * i) as *mut u8;
-        // SAFETY: `ptr` is valid for writes of `len` bytes, so `ptr_new` is valid for 8
-        // byte write SAFETY: `ptr` is 8 byte aligned, therefore `ptr_new` too
-        // (a multiple of 8 is added)
+    for _i in 0..nblocks {
+        // SAFETY: `ptr` originally pointed into an allocation of `len` bytes so now,
+        // after `_i` steps `len - 8*_i >= 8` bytes are left, so `ptr` is valid
+        // for an 8 byte write SAFETY: `ptr` was originally 8 byte aligned by
+        // caller contract and we only added a multiple of 8 so it is still 8
+        // byte aligned
         unsafe {
-            core::ptr::write_volatile(ptr_new as *mut u64, 0u64);
+            core::ptr::write_volatile(ptr.cast::<u64>(), 0u64);
         }
+        // SAFETY: after increment, `ptr` points into the same allocation or (if `8*_i
+        // == len`) at most one byte past it, so `add` is sound; `ptr` stays 8
+        // byte aligned
+        ptr = unsafe { ptr.add(8) };
     }
     // if `len` is not a multiple of 8 then the remainder (at most 7 bytes) needs to
-    // be zeroized if the remainder is at least 4 bytes we zero these with a
-    // single write
+    // be zeroized; if the remainder is at least 4 bytes we zero these with a single
+    // write
     if len % 8 >= 4 {
-        // `(ptr as usize) + (len - len % 8)` doesn't overflow since `ptr` is valid for
-        // `len` byte writes and `len % 8` is non-zero SAFETY: `(len - len % 8)
-        // + 4 =< len`
-        let ptr_new: *mut u32 = ((ptr as usize) + (len - len % 8)) as *mut u32;
-        // SAFETY: therefore, since `ptr` is valid for `len` byte writes, `ptr_new` is
-        // valid for a 4 byte write SAFETY: `ptr` is 8 byte aligned, therefore
-        // `ptr_new` too (a multiple of 8 is added)
+        // SAFETY: `ptr` has been incremented by a multiple of 8 <= `len` so `ptr`
+        // points to an allocation of `len % 8 >= 4` bytes, so `ptr` is valid
+        // for a 4 byte write SAFETY: `ptr` is still 8 byte aligned so also 4
+        // byte aligned
         unsafe {
-            core::ptr::write_volatile(ptr_new, 0u32);
+            core::ptr::write_volatile(ptr.cast::<u32>(), 0u32);
         }
+        ptr = unsafe { ptr.add(4) };
     }
     // the final remainder (at most 3 bytes) is zeroed byte-for-byte
-    for i in 0..(len % 4) {
-        // `(ptr as usize) - 1 + len - i` doesn't overflow overlow because `ptr` is
-        // valid for `len` writes, therefore non-zero, and the `+ len` then can't
-        // overflow since a write can't wrap the address space the trickery with
-        // the minus results in the most performant machine code (saves 1 instruction
-        // asm)
-        let ptr_new: *mut u8 = ((ptr as usize) - 1 + len - i) as *mut u8;
-        // SAFETY: `(ptr as usize) - 1 + len - i` ranges precisely `(len - len %
-        // 4)..len` SAFETY: `ptr` is valid for writes of `len` bytes, so
-        // `ptr_new` is valid for a byte write SAFETY: byte writes only require
-        // byte alignment which immediate
+    // SAFETY: `ptr` has been incremented by a multiple of 4 <= `len` so `ptr`
+    // points to an allocation of `len % 4` bytes, so `ptr` can be written to
+    // and incremented `len % 4` times
+    for _i in 0..(len % 4) {
         unsafe {
-            core::ptr::write_volatile(ptr_new, 0u8);
+            core::ptr::write_volatile(ptr, 0u8);
         }
+        ptr = unsafe { ptr.add(1) };
     }
 }
 

--- a/tests/zeroizing_global_alloc.rs
+++ b/tests/zeroizing_global_alloc.rs
@@ -6,8 +6,8 @@ static GLOBAL: ZeroizeAlloc<System> = ZeroizeAlloc::new(System);
 
 #[test]
 fn box_9b() {
-    let boxed = Box::new([1_u8; 9]);
-    // drop `boxed`
+    let _boxed = Box::new([1_u8; 9]);
+    // drop `_boxed`
 }
 
 #[test]


### PR DESCRIPTION
- Switch to rust 2021 edition
- Add `MAP_NOCORE` flag to `mmap` calls on freebsd-like systems, causing the allocated memory to not be included in coredumps
- Improve `VolatileWriteZeroizer` and `VolatileWrite8Zeroizer` zeroizer implementations to be slightly more performant and avoid int-ptr-casts to be nicer on `miri`, solving the miri failure caused by <https://github.com/rust-lang/miri/issues/1909> for now
- Fix several compile warnings