### PR TITLE
Miri enable tag-raw-ptr and check-number-validity

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,6 +152,7 @@ jobs:
         env:
           MIRI_LOG: 1
           MIRI_BACKTRACE: 1
+          MIRIFLAGS: -Zmiri-check-number-validity
 
   miri_raw_ptr:
     name: Miri tag-raw-pointers
@@ -176,4 +177,4 @@ jobs:
         env:
           MIRI_LOG: 1
           MIRI_BACKTRACE: 1
-          MIRIFLAGS: -Zmiri-tag-raw-pointers
+          MIRIFLAGS: -Zmiri-tag-raw-pointers -Zmiri-check-number-validity

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,3 +152,28 @@ jobs:
         env:
           MIRI_LOG: 1
           MIRI_BACKTRACE: 1
+
+  miri_raw_ptr:
+    name: Miri tag-raw-pointers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Get latest toolchain version with miri
+        run: echo "TOOLCHAIN=$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> $GITHUB_ENV
+
+      - name: Install latest nightly toolchain with miri
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-${{ env.TOOLCHAIN }}
+          override: true
+          components: rust-src, miri
+
+      - name: Run cargo miri test
+        run: cargo miri test --all-features
+        env:
+          MIRI_LOG: 1
+          MIRI_BACKTRACE: 1
+          MIRIFLAGS: -Zmiri-tag-raw-pointers

--- a/justfile
+++ b/justfile
@@ -9,10 +9,10 @@ test:
     cargo +nightly test --all-features
 
 miri:
-    cargo +nightly miri test --all-features
+    env MIRIFLAGS="-Zmiri-check-number-validity" cargo +nightly miri test --all-features
 
 miri-raw-ptr:
-    env MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo +nightly miri test --all-features
+    env MIRIFLAGS="-Zmiri-tag-raw-pointers -Zmiri-check-number-validity" cargo +nightly miri test --all-features
 
 full-test: test
     env CC="clang" env CFLAGS="-fsanitize=address -fno-omit-frame-pointer" env RUSTFLAGS="-C target-cpu=native -Z sanitizer=address" cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --tests --all-features

--- a/justfile
+++ b/justfile
@@ -11,6 +11,9 @@ test:
 miri:
     cargo +nightly miri test --all-features
 
+miri-raw-ptr:
+    env MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo +nightly miri test --all-features
+
 full-test: test
     env CC="clang" env CFLAGS="-fsanitize=address -fno-omit-frame-pointer" env RUSTFLAGS="-C target-cpu=native -Z sanitizer=address" cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --tests --all-features
     env CC="clang" env CFLAGS="-fsanitize=memory -fno-omit-frame-pointer" env RUSTFLAGS="-C target-cpu=native -Z sanitizer=memory" cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --tests --all-features
@@ -30,7 +33,7 @@ fmt-check:
 clippy:
     cargo +nightly clippy --all-features
 
-full-check: check full-test doc clippy fmt-check
+full-check: check full-test doc clippy fmt-check miri miri-raw-ptr
 
 bench:
     env RUSTFLAGS="-C target-cpu=native" cargo +nightly bench --all-features
@@ -49,10 +52,10 @@ generate-readme:
     cargo doc2readme
 
 dev-mirai:
-    env RUSTFLAGS="-Z always_encode_mir" env RUSTC_WRAPPER=mirai env MIRAI_FLAGS="--diag=library" cargo +nightly-2021-09-17 build --no-default-features --features nightly --features std
+    env RUSTFLAGS="-Z always_encode_mir" env RUSTC_WRAPPER=mirai env MIRAI_FLAGS="--diag=library" cargo +nightly-2021-11-17 build --no-default-features --features nightly --features std
 
 clean-mirai: clean
-    env RUSTFLAGS="-Z always_encode_mir" cargo +nightly-2021-09-17 build --no-default-features --features nightly --features std
+    env RUSTFLAGS="-Z always_encode_mir" cargo +nightly-2021-11-17 build --no-default-features --features nightly --features std
     touch src/lib.rs
-    env RUSTFLAGS="-Z always_encode_mir" env RUSTC_WRAPPER=mirai env MIRAI_FLAGS="--diag=library" cargo +nightly-2021-09-17 build --no-default-features --features nightly --features std
+    env RUSTFLAGS="-Z always_encode_mir" env RUSTC_WRAPPER=mirai env MIRAI_FLAGS="--diag=library" cargo +nightly-2021-11-17 build --no-default-features --features nightly --features std
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,7 +29,6 @@ macro_rules! debug_handleallocerror_precondition_valid_layout {
 
 macro_rules! precondition_memory_range {
     ($ptr:expr, $len:expr) => {
-        // !($ptr.is_null())
         mirai_annotations::precondition!(!($ptr.is_null()), "null pointer is never valid");
         mirai_annotations::precondition!(
             ($ptr as usize).checked_add($len).is_some(),

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,7 @@
 //! Mainly stable replacements for nightly only functionality.
 
 use core::ptr::NonNull;
+use mirai_annotations::debug_checked_precondition;
 
 #[cfg(not(feature = "nightly_core_intrinsics"))]
 pub(crate) fn likely(b: bool) -> bool {
@@ -27,4 +28,24 @@ pub(crate) fn unlikely(b: bool) -> bool {
 /// Stable version of nightly only `NonNull::<[T]>::as_mut_ptr` from std.
 pub(crate) fn nonnull_as_mut_ptr<T>(ptr: NonNull<[T]>) -> *mut T {
     ptr.as_ptr() as *mut T
+}
+
+/// Align pointer `ptr` upwards to `align`. The return value is a null-pointer
+/// iff `ptr` cannot be aligned to `align`. The resulting pointer has the same
+/// provenance as `ptr`.
+///
+/// # Safety
+/// `align` must be a power of two (2). The resulting pointer is potentially
+/// null and has the same provenance as `ptr` so be careful that it is in the
+/// required memory range before dereferencing it.
+pub(crate) unsafe fn align_ptr_mut(ptr: *mut u8, align: usize) -> *mut u8 {
+    debug_checked_precondition!(align.is_power_of_two());
+    // align `ptr` to `align` or `0` if not possible; as a usize
+    // `align - 1` doesn't wrap as `align` is a power of 2, so >= 1
+    let aligned: usize = (ptr as usize).wrapping_add(align - 1) & !(align - 1);
+    // compute the difference with the original pointer
+    let offset = aligned.wrapping_sub(ptr as usize);
+    // add the offset to the original pointer; this way we keep the original pointer
+    // provenance
+    ptr.wrapping_add(offset)
 }

--- a/src/zeroize/tests.rs
+++ b/src/zeroize/tests.rs
@@ -2,8 +2,8 @@ use super::*;
 
 fn test_b127_zeroizer<Z: MemZeroizer>(z: Z) {
     let mut array: [u8; 127] = [0xAF; 127];
+    let ptr: *mut u8 = (&mut array[..]).as_mut_ptr();
     unsafe {
-        let ptr: *mut u8 = (&mut array[..]).as_mut_ptr();
         z.zeroize_mem(ptr, 127);
     }
     assert_eq!(array, [0u8; 127]);
@@ -12,15 +12,16 @@ fn test_b127_zeroizer<Z: MemZeroizer>(z: Z) {
 fn test_b239_lowalign_zeroizer<Z: MemZeroizer>(z: Z) {
     // ensure we get 8 byte aligned memory
     let mut array: [u64; 30] = [0x_AFAFAFAF_AFAFAFAF; 30];
+
     // zeroize everything but the first byte, so the pointer to the memory will have
     // an alignment of 1 byte
-    unsafe {
-        let array_ptr: *mut u64 = (&mut array[..]).as_mut_ptr();
-        // 1 byte aligned
-        let ptr: *mut u8 = ((array_ptr as usize) + 1) as *mut u8;
-        // this should still be safe
-        z.zeroize_mem(ptr, 30 * 8 - 1);
-    }
+
+    let array_ptr: *mut u64 = (&mut array[..]).as_mut_ptr();
+    // 1 byte aligned; SAFETY: resulting `ptr` still pointing in array
+    let ptr: *mut u8 = unsafe { array_ptr.cast::<u8>().add(1) };
+    // this should still be safe
+    unsafe { z.zeroize_mem(ptr, 30 * 8 - 1) };
+
     let mut expected: [u64; 30] = [0; 30];
     expected[0] = u64::from_ne_bytes([0x_AF, 0, 0, 0, 0, 0, 0, 0]);
     assert_eq!(&array[..], &expected[..]);


### PR DESCRIPTION
- Remove int-to-ptr casts to make miri test work with tag-raw-ptr enabled.
- Enable `miri-tag-raw-ptr` and `miri-check-number-validity` in CI
  (`miri-tag-raw-ptr` uses a separate check since miri doesn't guaranty that all issues found `miri-tag-raw-ptr` disabled will also be with `miri-tag-raw-ptr` enabled)