### PR TITLE
Strict provenance

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -154,29 +154,4 @@ jobs:
         env:
           MIRI_LOG: 1
           MIRI_BACKTRACE: 1
-          MIRIFLAGS: -Zmiri-check-number-validity
-
-  miri_raw_ptr:
-    name: Miri tag-raw-pointers
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Get latest toolchain version with miri
-        run: echo "TOOLCHAIN=$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> $GITHUB_ENV
-
-      - name: Install latest nightly toolchain with miri
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-${{ env.TOOLCHAIN }}
-          override: true
-          components: rust-src, miri
-
-      - name: Run cargo miri test
-        run: cargo miri test --all-features
-        env:
-          MIRI_LOG: 1
-          MIRI_BACKTRACE: 1
-          MIRIFLAGS: -Zmiri-tag-raw-pointers -Zmiri-check-number-validity
+          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-check-number-validity

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ dev = ["std", "nightly_allocator_api"]
 cfg-if = "1.0"
 libc = "0.2"
 mirai-annotations = "1.12"
+sptr = "0.3"
 thiserror = {version = "1.0", optional = true}
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,15 @@ nightly_allocator_api = []
 nightly_core_intrinsics = []
 # even though stabilised, still necessary for avx512
 nightly_stdsimd = []
-nightly = ["nightly_allocator_api", "nightly_core_intrinsics", "nightly_stdsimd"]
+# enables strict provenance lints and uses strict provenance methods from std
+# instead of those from `sptr` (for inherent methods only)
+nightly_strict_provenance = []
+nightly = [
+    "nightly_allocator_api",
+    "nightly_core_intrinsics",
+    "nightly_stdsimd",
+    "nightly_strict_provenance",
+]
 # required features to run tests; additional features enable more tests
 dev = ["std", "nightly_allocator_api"]
 

--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ fn main() {
 ## Cargo features
 
  - `std` (default): Enable functionality that requires `std`. Currently only required for `Error` implements and required for tests. This feature is enabled by default.
- - `nightly_allocator_api` (requires nightly): Use the nightly allocator api from the standard library (actually the `core` crate), gated behind the nightly-only feature `allocator_api`. When disabled, a copy of the allocator api included in this crate, available through `secmem_alloc::allocator_api`, will be used. This features requires a nightly compiler.
- - `nightly_core_intrinsics` (requires nightly): Use the intrinsics from the standard library (actually the `core` crate), gated behind the nightly-only feature `core_intrinsics`. This enables the extremely fast `VolatileMemsetZeroizer` zeroizer, and various other small optimisations. This features requires a nightly compiler.
- - `nightly` (requires nightly): Enable all nightly-only features (i.e. the above two). Enabling this feature is highly recommended when a nightly compiler is available. This features requires a nightly compiler.
- - `dev` (requires nightly): This feature enables all features required to run the test-suite, and should only be enabled for that purpose. This features currently requires a nightly compiler.
+ - `nightly_allocator_api` (requires nightly): Use the nightly allocator api from the standard library (actually the `core` crate), gated behind the nightly-only feature `allocator_api`. When disabled, a copy of the allocator api included in this crate, available through `secmem_alloc::allocator_api`, will be used. This feature requires a nightly compiler.
+ - `nightly_core_intrinsics` (requires nightly): Use the intrinsics from the standard library (actually the `core` crate), gated behind the nightly-only feature `core_intrinsics`. This enables the extremely fast `VolatileMemsetZeroizer` zeroizer, and various other small optimisations. This feature requires a nightly compiler.
+ - `nightly_stdsimd` (requires nightly): Required for avx512 simd API in the standard libary, but currently unused. This feature requires a nightly compiler.
+ - `nightly_strict_provenance` (requires nightly): Enable strict provenance lints and (mostly) use strict provenance API provided by the standard library instead of the one from `sptr`. (Will still depend on and in a few places even use `sptr`.)
+ - `nightly` (requires nightly): Enable all nightly-only features (i.e. the above two). Enabling this feature is highly recommended when a nightly compiler is available. This feature requires a nightly compiler.
+ - `dev` (requires nightly): This feature enables all features required to run the test-suite, and should only be enabled for that purpose. This feature currently requires a nightly compiler.
 
 
 ## TODOs

--- a/justfile
+++ b/justfile
@@ -9,10 +9,7 @@ test:
     env RUSTFLAGS="-C target-cpu=native" cargo +nightly test --all-features
 
 miri:
-    env MIRIFLAGS="-Zmiri-check-number-validity" cargo +nightly miri test --all-features
-
-miri-raw-ptr:
-    env MIRIFLAGS="-Zmiri-tag-raw-pointers -Zmiri-check-number-validity" cargo +nightly miri test --all-features
+    env MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-check-number-validity" cargo +nightly miri test --all-features
 
 test-address-sanatize:
     env CC="clang" env CFLAGS="-fsanitize=address -fno-omit-frame-pointer" env RUSTFLAGS="-C target-cpu=native -Z sanitizer=address" cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --tests --all-features
@@ -35,7 +32,7 @@ fmt-check:
 clippy:
     cargo +nightly clippy --all-features
 
-full-check: check test test-memory-sanatize doc clippy fmt-check miri miri-raw-ptr
+full-check: check test test-memory-sanatize doc clippy fmt-check miri
 
 bench:
     env RUSTFLAGS="-C target-cpu=native" cargo +nightly criterion --all-features

--- a/src/internals/zeroize.rs
+++ b/src/internals/zeroize.rs
@@ -36,6 +36,7 @@ pub unsafe fn volatile_memset(ptr: *mut u8, val: u8, len: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sptr::Strict;
 
     fn test_b128_zeroizer<Z: FnOnce(*mut u8, usize)>(zeroize: Z) {
         let mut array: [u8; 128] = [0xAF; 128];
@@ -54,7 +55,7 @@ mod tests {
 
         assert_eq!(array.0[0..256], [0u8; 256]);
         assert_eq!(array.0[256], 0xAF);
-        assert_eq!(new_ptr as usize, &array.0[256] as *const u8 as usize)
+        assert_eq!(new_ptr.addr(), (&array.0[256] as *const u8).addr())
     }
 
     fn test_b239_lowalign_zeroizer<Z: FnOnce(*mut u8, usize)>(zeroize: Z) {

--- a/src/internals/zeroize/asm_x86_64.rs
+++ b/src/internals/zeroize/asm_x86_64.rs
@@ -2,6 +2,8 @@
 //! cpus.
 
 use crate::macros::precondition_memory_range;
+use crate::util::is_aligned_ptr_mut;
+use mirai_annotations::debug_checked_precondition;
 
 /// Overwrite memory with zeros. This operation will not be elided by the
 /// compiler.
@@ -57,7 +59,7 @@ pub unsafe fn x86_64_simd16_zeroize_align16_block16(mut ptr: *mut u8, len: usize
     use core::arch::x86_64 as arch;
 
     precondition_memory_range!(ptr, len);
-    mirai_annotations::debug_checked_precondition_eq!((ptr as usize) % 16, 0);
+    debug_checked_precondition!(is_aligned_ptr_mut(ptr, 16));
 
     let nblocks = (len - len % 16) / 16;
 
@@ -110,6 +112,9 @@ pub unsafe fn x86_64_simd16_unroll2_zeroize_align16_block16(
     len: usize,
 ) -> *mut u8 {
     use core::arch::x86_64 as arch;
+
+    precondition_memory_range!(ptr, len);
+    debug_checked_precondition!(is_aligned_ptr_mut(ptr, 16));
 
     let nblocks = (len - len % 16) / 16;
 
@@ -170,7 +175,7 @@ pub unsafe fn x86_64_simd32_zeroize_align32_block32(mut ptr: *mut u8, len: usize
     use core::arch::x86_64 as arch;
 
     precondition_memory_range!(ptr, len);
-    mirai_annotations::debug_checked_precondition_eq!((ptr as usize) % 32, 0);
+    debug_checked_precondition!(is_aligned_ptr_mut(ptr, 32));
 
     let nblocks = (len - len % 32) / 32;
 
@@ -225,7 +230,7 @@ pub unsafe fn x86_64_simd32_unroll2_zeroize_align32_block32(
     use core::arch::x86_64 as arch;
 
     precondition_memory_range!(ptr, len);
-    mirai_annotations::debug_checked_precondition_eq!((ptr as usize) % 32, 0);
+    debug_checked_precondition!(is_aligned_ptr_mut(ptr, 32));
 
     let nblocks = (len - len % 32) / 32;
 
@@ -290,7 +295,7 @@ pub unsafe fn x86_64_simd64_zeroize_align64_block64(mut ptr: *mut u8, len: usize
     use core::arch::x86_64 as arch;
 
     precondition_memory_range!(ptr, len);
-    mirai_annotations::debug_checked_precondition_eq!((ptr as usize) % 64, 0);
+    debug_checked_precondition!(is_aligned_ptr_mut(ptr, 64));
 
     let nblocks = (len - len % 64) / 64;
 

--- a/src/internals/zeroize/volatile_write.rs
+++ b/src/internals/zeroize/volatile_write.rs
@@ -2,7 +2,8 @@
 //! cross-platform volatile writes.
 
 use crate::macros::precondition_memory_range;
-use mirai_annotations::debug_checked_precondition_eq;
+use crate::util::is_aligned_ptr_mut;
+use mirai_annotations::debug_checked_precondition;
 
 /// Zeroize the memory pointed to by `ptr` and of size `len` bytes, by
 /// overwriting it byte for byte using volatile writes.
@@ -43,7 +44,7 @@ pub unsafe fn volatile_write_zeroize(mut ptr: *mut u8, len: usize) {
 /// Furthermore, `ptr` *must* be at least 8 byte aligned.
 pub unsafe fn zeroize_align8_block8(mut ptr: *mut u8, len: usize) -> *mut u8 {
     precondition_memory_range!(ptr, len);
-    debug_checked_precondition_eq!((ptr as usize) % 8, 0);
+    debug_checked_precondition!(is_aligned_ptr_mut(ptr, 8));
 
     let nblocks = (len - len % 8) / 8;
     for _i in 0..nblocks {
@@ -76,7 +77,7 @@ pub unsafe fn zeroize_align8_block8(mut ptr: *mut u8, len: usize) -> *mut u8 {
 /// Furthermore, `ptr` *must* be at least 4 byte aligned.
 pub unsafe fn zeroize_align4_tail8(mut ptr: *mut u8, len: usize) {
     precondition_memory_range!(ptr, len);
-    debug_checked_precondition_eq!((ptr as usize) % 4, 0);
+    debug_checked_precondition!(is_aligned_ptr_mut(ptr, 4));
 
     if len % 8 >= 4 {
         // SAFETY: `ptr` is valid for `len % 8` bytes by caller contract

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@
 #![cfg_attr(feature = "nightly_core_intrinsics", feature(core_intrinsics))]
 #![cfg_attr(feature = "nightly_stdsimd", feature(stdsimd))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![forbid(future_incompatible, rust_2018_compatibility, unsafe_op_in_unsafe_fn)]
-#![deny(rust_2018_idioms)]
+#![forbid(rust_2018_compatibility, unsafe_op_in_unsafe_fn)]
+#![deny(future_incompatible, rust_2018_idioms)]
 #![warn(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+// FIXME: disable when strict provenance is stabilised
+#![allow(unstable_name_collisions)]
 //! `secmem-alloc` is a crate designed allocate private/secret memory. It is
 //! intended to be used for storing cryptographic secrets in memory. This crate
 //! provides custom allocators using various techniques to improve secrecy of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 #![cfg_attr(feature = "nightly_allocator_api", feature(allocator_api))]
 #![cfg_attr(feature = "nightly_core_intrinsics", feature(core_intrinsics))]
 #![cfg_attr(feature = "nightly_stdsimd", feature(stdsimd))]
+#![cfg_attr(feature = "nightly_strict_provenance", feature(strict_provenance))]
+#![cfg_attr(
+    feature = "nightly_strict_provenance",
+    deny(fuzzy_provenance_casts, lossy_provenance_casts)
+)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(rust_2018_compatibility, unsafe_op_in_unsafe_fn)]
 #![deny(future_incompatible, rust_2018_idioms)]
@@ -82,19 +87,26 @@
 //!   from the standard library (actually the `core` crate), gated behind the
 //!   nightly-only feature `allocator_api`. When disabled, a copy of the
 //!   allocator api included in this crate, available through
-//!   `secmem_alloc::allocator_api`, will be used. This features requires a
+//!   `secmem_alloc::allocator_api`, will be used. This feature requires a
 //!   nightly compiler.
 //! - `nightly_core_intrinsics` (requires nightly): Use the intrinsics from the
 //!   standard library (actually the `core` crate), gated behind the
 //!   nightly-only feature `core_intrinsics`. This enables the extremely fast
 //!   `VolatileMemsetZeroizer` zeroizer, and various other small optimisations.
-//!   This features requires a nightly compiler.
+//!   This feature requires a nightly compiler.
+//! - `nightly_stdsimd` (requires nightly): Required for avx512 simd API in the
+//!   standard libary, but currently unused. This feature requires a nightly
+//!   compiler.
+//! - `nightly_strict_provenance` (requires nightly): Enable strict provenance
+//!   lints and (mostly) use strict provenance API provided by the standard
+//!   library instead of the one from `sptr`. (Will still depend on and in a few
+//!   places even use `sptr`.)
 //! - `nightly` (requires nightly): Enable all nightly-only features (i.e. the
 //!   above two). Enabling this feature is highly recommended when a nightly
-//!   compiler is available. This features requires a nightly compiler.
+//!   compiler is available. This feature requires a nightly compiler.
 //! - `dev` (requires nightly): This feature enables all features required to
 //!   run the test-suite, and should only be enabled for that purpose. This
-//!   features currently requires a nightly compiler.
+//!   feature currently requires a nightly compiler.
 
 extern crate alloc;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -6,7 +6,7 @@ macro_rules! debug_handleallocerror_precondition {
         if cfg!(debug_assertions) {
             // check that `layout` is a valid layout
             if !($condition) {
-                handle_alloc_error($layout);
+                alloc::alloc::handle_alloc_error($layout);
             }
         }
     };
@@ -15,13 +15,13 @@ macro_rules! debug_handleallocerror_precondition {
 macro_rules! debug_handleallocerror_precondition_valid_layout {
     ($layout:ident) => {
         mirai_annotations::precondition!(
-            Layout::from_size_align($layout.size(), $layout.align()).is_ok(),
+            core::alloc::Layout::from_size_align($layout.size(), $layout.align()).is_ok(),
             "invalid layout"
         );
         if cfg!(debug_assertions) {
             // check that `layout` is a valid layout
-            if Layout::from_size_align($layout.size(), $layout.align()).is_err() {
-                handle_alloc_error($layout);
+            if core::alloc::Layout::from_size_align($layout.size(), $layout.align()).is_err() {
+                alloc::alloc::handle_alloc_error($layout);
             }
         }
     };
@@ -31,7 +31,7 @@ macro_rules! precondition_memory_range {
     ($ptr:expr, $len:expr) => {
         mirai_annotations::precondition!(!($ptr.is_null()), "null pointer is never valid");
         mirai_annotations::precondition!(
-            ($ptr as usize).checked_add($len).is_some(),
+            sptr::Strict::addr($ptr).checked_add($len).is_some(),
             "memory range wraps the address space"
         );
     };
@@ -58,7 +58,7 @@ macro_rules! debug_precondition_logaligned {
             "alignment must fit a usize"
         );
         mirai_annotations::debug_checked_precondition_eq!(
-            ($ptr as usize) % 2_usize.pow($logalign.into()),
+            sptr::Strict::addr($ptr) % 2_usize.pow($logalign.into()),
             0,
             "pointer must be aligned"
         );

--- a/src/sec_alloc.rs
+++ b/src/sec_alloc.rs
@@ -31,6 +31,7 @@ use core::alloc::Layout;
 use core::cell::Cell;
 use core::ptr::{self, NonNull};
 use mirai_annotations::debug_checked_precondition;
+#[cfg(not(feature = "nightly_strict_provenance"))]
 use sptr::Strict;
 
 /// Memory allocator for confidential memory. See the module level

--- a/src/sec_alloc.rs
+++ b/src/sec_alloc.rs
@@ -22,12 +22,16 @@
 
 use crate::allocator_api::{AllocError, Allocator};
 use crate::internals::mem;
-use crate::util::{align_ptr_mut, nonnull_as_mut_ptr, unlikely};
+use crate::util::{
+    align_up_ptr_mut, align_up_usize, is_aligned_ptr, large_offset_from, nonnull_as_mut_ptr,
+    unlikely,
+};
 use crate::zeroize::{DefaultMemZeroizer, MemZeroizer};
 use core::alloc::Layout;
 use core::cell::Cell;
 use core::ptr::{self, NonNull};
 use mirai_annotations::debug_checked_precondition;
+use sptr::Strict;
 
 /// Memory allocator for confidential memory. See the module level
 /// documentation.
@@ -102,7 +106,7 @@ impl<Z: MemZeroizer> SecStackSinglePageAlloc<Z> {
             "safety critical SecStackSinglePageAlloc invariant: offset in page size"
         );
         assert!(
-            self.page.as_ptr() as usize % 8 == 0,
+            is_aligned_ptr(self.page.as_ptr(), 8),
             "safety critical SecStackSinglePageAlloc invariant: page alignment"
         );
         assert!(
@@ -219,9 +223,10 @@ impl<Z: MemZeroizer> SecStackSinglePageAlloc<Z> {
     /// `false` even if the allocation pointed to by `ptr` is actually the
     /// final allocation.
     fn ptr_is_last_allocation(&self, ptr: NonNull<u8>, rounded_size: usize) -> bool {
-        // this doesn't overflow as `ptr` was returned by a previous allocation request
-        // so lies in our memory page, so `ptr` is larger than the page pointer
-        let alloc_start_offset = ptr.as_ptr() as usize - self.page.as_ptr() as usize;
+        // SAFETY: this doesn't overflow as `ptr` was returned by a previous allocation
+        // request so lies in our memory page, so `ptr` is larger than the page
+        // pointer
+        let alloc_start_offset = unsafe { large_offset_from(ptr.as_ptr(), self.page.as_ptr()) };
         // this doesn't overflow since `rounded_size` fits the allocation pointed to by
         // `ptr`
         let alloc_end_offset = alloc_start_offset + rounded_size;
@@ -238,7 +243,7 @@ impl<Z: MemZeroizer> SecStackSinglePageAlloc<Z> {
         debug_checked_precondition!(align.is_power_of_two());
 
         // SAFETY: creating a pointer is safe, using it not; `dangling` is non-null
-        let dangling: *mut u8 = align as *mut u8;
+        let dangling: *mut u8 = sptr::invalid_mut(align);
         let zerosized_slice: *mut [u8] = ptr::slice_from_raw_parts_mut(dangling, 0);
         // SAFETY: zerosized_slice has a non-null pointer part since `align` > 0
         unsafe { NonNull::new_unchecked(zerosized_slice) }
@@ -390,15 +395,16 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
             // slower path for large align
             // first pointer >= `stack_ptr` which is `layout.align()` bytes aligned
             // SAFETY: `layout.align()` is a power of 2
-            let next_aligned_ptr = unsafe { align_ptr_mut(stack_ptr, layout.align()) };
+            let next_aligned_ptr = unsafe { align_up_ptr_mut(stack_ptr, layout.align()) };
             // if this wraps the address space, then the result is null and the layout
             // doesn't fit the remaining memory of our page, so error
             if unlikely(next_aligned_ptr.is_null()) {
                 return Err(AllocError);
             }
-            // offset of `next_align_ptr` relative from our base page pointer; doesn't wrap
-            // since `next_align_ptr` is higher in the memory than `stack_ptr`
-            let next_align_pageoffset = next_aligned_ptr as usize - (self.page.as_ptr() as usize);
+            // offset of `next_align_ptr` relative from our base page pointer
+            // SAFETY: `next_align_ptr` is higher in the memory than `stack_ptr`
+            let next_align_pageoffset =
+                unsafe { large_offset_from(next_aligned_ptr, self.page.as_ptr()) };
             // error if `next_aligned_ptr` falls outside of our page
             if next_align_pageoffset >= self.page.page_size() {
                 return Err(AllocError);
@@ -447,9 +453,9 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
 
         // `ptr` must be returned by this allocator, so it lies in the currently used
         // part of the memory page
-        debug_checked_precondition!(self.page.as_ptr() as usize <= ptr.as_ptr() as usize);
+        debug_checked_precondition!(self.page.as_ptr().addr() <= ptr.as_ptr().addr());
         debug_checked_precondition!(
-            ptr.as_ptr() as usize <= self.page.as_ptr() as usize + self.stack_offset.get()
+            ptr.as_ptr().addr() <= self.page.as_ptr().addr() + self.stack_offset.get()
         );
 
         // SAFETY: this `rounded_req_size` is identical to the value of
@@ -458,7 +464,7 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
         // so `layout.size()` now is in the range `layout.size() ..=
         // rounded_req_size` for the values back then this will be important for
         // safety and correct functioning
-        let rounded_req_size = layout.size().wrapping_add(7usize) & !7usize;
+        let rounded_req_size = align_up_usize(layout.size(), 8);
         // securely wipe the deallocated memory
         // SAFETY: `ptr` is valid for writes of `rounded_req_size` bytes since it was
         // previously successfully allocated (by the safety contract for this
@@ -483,9 +489,10 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
         // otherwise, if this allocation was the last one on the stack, rewind the stack
         // offset so we can reuse the memory for later allocation requests
 
-        // this doesn't overflow as `ptr` was returned by a previous allocation request
-        // so lies in our memory page, so `ptr` is larger than the page pointer
-        let alloc_start_offset = ptr.as_ptr() as usize - self.page.as_ptr() as usize;
+        // SAFETY: this doesn't overflow as `ptr` was returned by a previous allocation
+        // request so lies in our memory page, so `ptr` is larger than the page
+        // pointer
+        let alloc_start_offset = unsafe { large_offset_from(ptr.as_ptr(), self.page.as_ptr()) };
         let alloc_end_offset = alloc_start_offset + rounded_req_size;
         // `alloc_end_offset` is the stack offset directly after it's allocation
         if alloc_end_offset == self.stack_offset.get() {
@@ -520,13 +527,13 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
 
         // `ptr` must be returned by this allocator, so it lies in the currently used
         // part of the memory page
-        debug_checked_precondition!(self.page.as_ptr() as usize <= ptr.as_ptr() as usize);
+        debug_checked_precondition!(self.page.as_ptr().addr() <= ptr.as_ptr().addr());
         debug_checked_precondition!(
-            ptr.as_ptr() as usize <= self.page.as_ptr() as usize + self.stack_offset.get()
+            ptr.as_ptr().addr() <= self.page.as_ptr().addr() + self.stack_offset.get()
         );
 
         // check whether the existing allocation has the requested alignment
-        if (ptr.as_ptr() as usize) % new_layout.align() == 0 {
+        if is_aligned_ptr(ptr.as_ptr(), new_layout.align()) {
             // old allocation has the (new) required alignment
             // we can shrink the allocation in place
             // for a non-final allocation (not last allocation on the memory page) this
@@ -536,12 +543,12 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
 
             // round old layout size to a multiple of 8, since allocation sizes are
             // multiples of 8
-            let rounded_size: usize = old_layout.size().wrapping_add(7usize) & !7usize;
+            let rounded_size: usize = align_up_usize(old_layout.size(), 8);
             // if the allocation is the final allocation in our memory page, then we can
             // shrink
 
             // shrink in place
-            let new_rounded_size: usize = new_layout.size().wrapping_add(7usize) & !7usize;
+            let new_rounded_size: usize = align_up_usize(new_layout.size(), 8);
             // SAFETY: `ptr` points to an allocation of size at least `rounded_size`, and
             // `new_rounded_size` not larger, so `ptr + new_rounded_size` still points
             // inside our memory page
@@ -610,36 +617,37 @@ unsafe impl<Z: MemZeroizer> Allocator for SecStackSinglePageAlloc<Z> {
 
         // `ptr` must be returned by this allocator, so it lies in the currently used
         // part of the memory page
-        debug_checked_precondition!(self.page.as_ptr() as usize <= ptr.as_ptr() as usize);
+        debug_checked_precondition!(self.page.as_ptr().addr() <= ptr.as_ptr().addr());
         debug_checked_precondition!(
-            ptr.as_ptr() as usize <= self.page.as_ptr() as usize + self.stack_offset.get()
+            ptr.as_ptr().addr() <= self.page.as_ptr().addr() + self.stack_offset.get()
         );
 
         // check whether the existing allocation has the requested alignment
-        if (ptr.as_ptr() as usize) % new_layout.align() == 0 {
+        if is_aligned_ptr(ptr.as_ptr(), new_layout.align()) {
             // old allocation has the (new) required alignment
             // if the allocation is the final allocation in our memory page, then we can
             // increase the allocation in-place
 
             // round old layout size to a multiple of 8, since allocation sizes are
             // multiples of 8
-            let rounded_size: usize = old_layout.size().wrapping_add(7usize) & !7usize;
+            let rounded_size: usize = align_up_usize(old_layout.size(), 8);
             // `ptr` is allocated with `self` and `rounded_size` fits it and is a multiple
             // of 8
             if self.ptr_is_last_allocation(ptr, rounded_size) {
                 // increase allocation in-place
 
-                let new_rounded_size: usize = new_layout.size().wrapping_add(7usize) & !7usize;
+                let new_rounded_size: usize = align_up_usize(new_layout.size(), 8);
                 // if this wraps the address space, then the result is 0 and the layout doesn't
                 // fit the remaining memory of our page, so error
                 if unlikely(new_rounded_size == 0) {
                     return Err(AllocError);
                 }
 
-                // this doesn't overflow as `ptr` was returned by a previous allocation request
-                // so lies in our memory page, so `ptr` is larger than the page
-                // pointer
-                let alloc_start_offset = ptr.as_ptr() as usize - self.page.as_ptr() as usize;
+                // SAFETY: this doesn't overflow as `ptr` was returned by a previous allocation
+                // request so lies in our memory page, so `ptr` is larger than
+                // the page pointer
+                let alloc_start_offset =
+                    unsafe { large_offset_from(ptr.as_ptr(), self.page.as_ptr()) };
                 // if the requested allocation size doesn't fit the rest of our page, error
                 // the subtraction doesn't wrap since `alloc_start_offset` is the part of the
                 // page that is used (without counting the allocation currently

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,7 @@
 
 use core::ptr::NonNull;
 use mirai_annotations::debug_checked_precondition;
+#[cfg(not(feature = "nightly_strict_provenance"))]
 use sptr::Strict;
 
 #[cfg(not(feature = "nightly_core_intrinsics"))]

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,7 @@
 
 use core::ptr::NonNull;
 use mirai_annotations::debug_checked_precondition;
+use sptr::Strict;
 
 #[cfg(not(feature = "nightly_core_intrinsics"))]
 pub(crate) fn likely(b: bool) -> bool {
@@ -30,6 +31,16 @@ pub(crate) fn nonnull_as_mut_ptr<T>(ptr: NonNull<[T]>) -> *mut T {
     ptr.as_ptr() as *mut T
 }
 
+/// Round `x` up to the smallest multiple of `div` >= `x`, where `div` is
+/// expected to be a power of 2.
+///
+/// If `div` is not a power of two (2), then the function might panic or give a
+/// wrong  result.
+pub(crate) fn align_up_usize(x: usize, div: usize) -> usize {
+    debug_checked_precondition!(div.is_power_of_two());
+    x.wrapping_add(div - 1) & !(div - 1)
+}
+
 /// Align pointer `ptr` upwards to `align`. The return value is a null-pointer
 /// iff `ptr` cannot be aligned to `align`. The resulting pointer has the same
 /// provenance as `ptr`.
@@ -38,14 +49,37 @@ pub(crate) fn nonnull_as_mut_ptr<T>(ptr: NonNull<[T]>) -> *mut T {
 /// `align` must be a power of two (2). The resulting pointer is potentially
 /// null and has the same provenance as `ptr` so be careful that it is in the
 /// required memory range before dereferencing it.
-pub(crate) unsafe fn align_ptr_mut(ptr: *mut u8, align: usize) -> *mut u8 {
+pub(crate) unsafe fn align_up_ptr_mut(ptr: *mut u8, align: usize) -> *mut u8 {
     debug_checked_precondition!(align.is_power_of_two());
-    // align `ptr` to `align` or `0` if not possible; as a usize
+    // align `ptr` to `align` or make it null if not possible
     // `align - 1` doesn't wrap as `align` is a power of 2, so >= 1
-    let aligned: usize = (ptr as usize).wrapping_add(align - 1) & !(align - 1);
-    // compute the difference with the original pointer
-    let offset = aligned.wrapping_sub(ptr as usize);
-    // add the offset to the original pointer; this way we keep the original pointer
-    // provenance
-    ptr.wrapping_add(offset)
+    ptr.map_addr(|addr| align_up_usize(addr, align))
+}
+
+/// Returns `true` iff `ptr` is `align` byte aligned.
+///
+/// For the result to be correct, `align` must be a power of two (2).
+/// Might panic if `align` is not a power of two.
+pub(crate) fn is_aligned_ptr(ptr: *const u8, align: usize) -> bool {
+    debug_checked_precondition!(align.is_power_of_two());
+    ptr.addr() % align == 0
+}
+
+/// Returns `true` iff `ptr` is `align` byte aligned.
+///
+/// For the result to be correct, `align` must be a power of two (2).
+/// Might panic if `align` is not a power of two.
+pub(crate) fn is_aligned_ptr_mut(ptr: *mut u8, align: usize) -> bool {
+    debug_checked_precondition!(align.is_power_of_two());
+    ptr.addr() % align == 0
+}
+
+/// Returns the offset in bytes of `ptr` relative to `base`. Must not wrap.
+///
+/// # Safety
+/// `ptr.addr()` must be at least as large as `base.addr()`.
+// actually the implementation just panics or wraps when that is not the case
+pub(crate) unsafe fn large_offset_from(ptr: *const u8, base: *const u8) -> usize {
+    debug_checked_precondition!(ptr.addr() >= base.addr());
+    ptr.addr() - base.addr()
 }

--- a/src/zeroizing_alloc.rs
+++ b/src/zeroizing_alloc.rs
@@ -18,6 +18,7 @@ use crate::zeroize::{DefaultMemZeroizer, DefaultMemZeroizerConstructor, MemZeroi
 use alloc::alloc::handle_alloc_error;
 use core::alloc::{GlobalAlloc, Layout};
 use core::ptr::NonNull;
+use sptr::Strict;
 
 /// Wrapper around an allocator which zeroizes memory on deallocation. See the
 /// module level documentation.
@@ -93,7 +94,7 @@ where
 
         if cfg!(debug_assertions) {
             // you can't wrap around the address space
-            if (ptr as usize).checked_add(layout.size()).is_none() {
+            if ptr.addr().checked_add(layout.size()).is_none() {
                 handle_alloc_error(layout);
             }
         }

--- a/src/zeroizing_alloc.rs
+++ b/src/zeroizing_alloc.rs
@@ -18,6 +18,7 @@ use crate::zeroize::{DefaultMemZeroizer, DefaultMemZeroizerConstructor, MemZeroi
 use alloc::alloc::handle_alloc_error;
 use core::alloc::{GlobalAlloc, Layout};
 use core::ptr::NonNull;
+#[cfg(not(feature = "nightly_strict_provenance"))]
 use sptr::Strict;
 
 /// Wrapper around an allocator which zeroizes memory on deallocation. See the


### PR DESCRIPTION
- Set miri to strict provenance mode
- Use `sptr` crate (or strict provenance API on nightly) to ease obaying  to strict provenance (the code already conformed)
- Split out many helper functions to work with pointers into functions in `util`
- Enable strict provenance lints on nightly